### PR TITLE
Fix issues with out of source build CMake install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,4 +491,5 @@ if(TESTS)
 
 endif()
 
-install(FILES picolibc.specs DESTINATION lib)
+install(FILES ${CMAKE_BINARY_DIR}/picolibc.specs DESTINATION lib)
+install(FILES ${CMAKE_BINARY_DIR}/picolibc/include/picolibc.h DESTINATION include)


### PR DESCRIPTION
The picolibc.specs file lives in the build directory, not the source directory.
The picolibc.h file wasn't getting copied to the install include directory.